### PR TITLE
Remove dependency on workbench.help

### DIFF
--- a/de.mpc.pia.update/buckminster.cspex
+++ b/de.mpc.pia.update/buckminster.cspex
@@ -2,8 +2,6 @@
 <cspecExtension xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bc="http://www.eclipse.org/buckminster/Common-1.0"
     xmlns="http://www.eclipse.org/buckminster/CSpec-1.0">
     <dependencies>
-        <!-- necessary for for the automated build system -->
-        <dependency name="org.knime.workbench.help" versionDesignator="2.4.0" componentType="osgi.bundle" />
         <dependency name="org.knime.product" componentType="osgi.bundle" />
 
         <!-- necessary for all SWT fragments -->


### PR DESCRIPTION
This makes the extension build compatible with 4.7 and also does not break compatibility with earlier versions